### PR TITLE
added paging system for email lists

### DIFF
--- a/APIEndPoints.md
+++ b/APIEndPoints.md
@@ -241,4 +241,31 @@
   {
     "message": "Compliance settings updated successfully"
   }
-  
+  ```
+
+### 14. **GET email list: Pagination for email lists**
+**GET** `/api/email-lists`
+- **Description**: Fetches a paginated list of email records.
+- **Headers**:
+  - Authorization: `Bearer <token>`
+- **Query Parameters**
+- ```Parameter	       Type	      Default	            Description
+-     page	          Number	      1	          The page number to retrieve.
+-     limit	        Number	      10	        Number of items to fetch per page.
+  ```
+- **Response**:
+  ```json
+  {
+    "success": true,
+    "data": [
+      { "id": "integer", "email": "string" },
+      { "id": "integer", "email": "string" }
+    ],
+    "meta": {
+      "currentPage": 1,
+      "totalPages": 5,
+      "totalItems": 50,
+      "limit": 10
+    }
+  }
+  ```

--- a/controllers/emailListController.js
+++ b/controllers/emailListController.js
@@ -47,8 +47,45 @@ const EmailList = require("../models/User");
     }
 }
 
+// to get paginated email lists, on route /api/email-lists?page=1&limit=50
+const getPaginatedEmailLists = async (req, res) => {
+    try {
+        console.log('GET /api/email-lists request received');  
 
+      // Extract page and limit query parameters, with defaults
+      const page = parseInt(req.query.page) || 1; // Default page = 1
+      const limit = parseInt(req.query.limit) || 10; // Default limit = 10
+  
+      if (page < 1 || limit < 1) {
+        return res.status(400).json({ message: "Page and limit must be positive integers." });
+      }
+  
+      const skip = (page - 1) * limit;
+
+      const [data, totalItems] = await Promise.all([
+        EmailList.find().skip(skip).limit(limit),
+        EmailList.countDocuments() 
+      ]);
+  
+      const totalPages = Math.ceil(totalItems / limit);
+
+      res.status(200).json({
+        success: true,
+        data,
+        meta: {
+          currentPage: page,
+          totalPages,
+          totalItems,
+          limit
+        }
+      });
+    } catch (error) {
+      console.error("Error fetching paginated email lists:", error);
+      res.status(500).json({ success: false, message: "Server Error" });
+    }
+  };
 module.exports = {
     updateEmailListTags,
-    getEmailListTags
+    getEmailListTags,
+    getPaginatedEmailLists
 }

--- a/routes/emailListRoutes.js
+++ b/routes/emailListRoutes.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const { updateEmailListTags, getEmailListTags } = require("../controllers/emailListController");
+const { updateEmailListTags, getEmailListTags, getPaginatedEmailLists } = require("../controllers/emailListController");
 
 const router = express.Router();
 
@@ -9,5 +9,8 @@ router.patch("/:id/tags", updateEmailListTags);
 
 // to get tags of an email list send a get request on route /api/email-lists/:id a array of tags will be returned in response
 router.get("/:id", getEmailListTags);
+
+// Route to get paginated email lists
+router.get("/", getPaginatedEmailLists);
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ app.get("/", (req, res) => {
 app.use("/user", authRoute);
 app.use("/api/template", templateRoute);
 
-app.get("/api/email-lists", router);
+app.use("/api/email-lists", router);
 
 // Start Server
 const PORT = process.env.PORT || 5000;


### PR DESCRIPTION
Issue: #9 

Description:

- Implemented pagination for the GET /api/email-lists endpoint to retrieve a paginated list of email records.
- Added query parameters (page and limit) to allow users to specify the page number and the number of items per page.
- Ensured that the response includes metadata such as currentPage, totalPages, totalItems, and limit
- Verified the changes by testing the endpoint and ensuring accurate paginated responses.
- added api endpoints

Screenshot: 
![Screenshot 2024-12-18 011046](https://github.com/user-attachments/assets/cc63463c-21ac-4462-95a2-f4600ab1041d)
![Screenshot 2024-12-18 011207](https://github.com/user-attachments/assets/e72f35b8-818e-4a26-86af-9def1929111d)

